### PR TITLE
extend range of Plumi interpolation function

### DIFF
--- a/parton/pdf.py
+++ b/parton/pdf.py
@@ -223,11 +223,11 @@ class PLumi(object):
             return self.pdf.xfxQ2(p1, x, self.Q2).ravel() / x
         def f2(x):
             return self.pdf.xfxQ2(p2, x, self.Q2).ravel() / x
-        _Lx = np.logspace(np.log10(self.x_min), 0, num=self.N)
-        _f1 = f1(_Lx)
-        _f2 = f2(_Lx)
+        _x = np.logspace(np.log10(self.x_min), 0, num=self.N)
+        _f1 = f1(_x)
+        _f2 = f2(_x)
         _y = np.convolve(_f1, _f2, 'full')[-self.N:] / self.N * (-np.log(self.x_min))
-        return scipy.interpolate.interp1d(np.log(_Lx), _y, kind='cubic', bounds_error=False, fill_value=np.nan)
+        return scipy.interpolate.interp1d(np.log(_x), _y, kind='cubic', bounds_error=False, fill_value=np.nan)
 
     def interpolator(self, p1, p2):
         """Return an instance of the `scipy.interpolate.interp1d` interpolator

--- a/parton/pdf.py
+++ b/parton/pdf.py
@@ -214,7 +214,8 @@ class PLumi(object):
         for the factorization scale squared `Q2` in GeV^2."""
         self.pdf = pdf
         self.Q2 = Q2
-        self.N = 200
+        self.N = 1000
+        self.x_min = np.min([np.min(v.x) for v in pdf.pdfgrids])
         self._interpolators = {}
 
     def _interpolator(self, p1, p2):
@@ -222,11 +223,11 @@ class PLumi(object):
             return self.pdf.xfxQ2(p1, x, self.Q2).ravel() / x
         def f2(x):
             return self.pdf.xfxQ2(p2, x, self.Q2).ravel() / x
-        _Lx = np.linspace(-10, 0, num=self.N)
-        _f1 = np.flip(f1(np.exp(_Lx)).ravel(), 0)
-        _f2 = np.flip(f2(np.exp(_Lx)).ravel(), 0)
-        _y = np.convolve(_f1, _f2, 'full')[:self.N] / self.N * 10
-        return scipy.interpolate.interp1d(np.flip(_Lx, 0), _y, kind='cubic', bounds_error=False, fill_value=np.nan)
+        _Lx = np.logspace(np.log10(self.x_min), 0, num=self.N)
+        _f1 = f1(_Lx)
+        _f2 = f2(_Lx)
+        _y = np.convolve(_f1, _f2, 'full')[-self.N:] / self.N * (-np.log(self.x_min))
+        return scipy.interpolate.interp1d(np.log(_Lx), _y, kind='cubic', bounds_error=False, fill_value=np.nan)
 
     def interpolator(self, p1, p2):
         """Return an instance of the `scipy.interpolate.interp1d` interpolator

--- a/parton/test_plumi.py
+++ b/parton/test_plumi.py
@@ -16,9 +16,9 @@ def interpolator_slow(pl, p1, p2):
         def _int(x):
             return f1(x) * f2(t / x) / x
         return scipy.integrate.quad(lambda x: _int(x), t, 1)[0]
-    _Lx = np.logspace(np.log10(pl.x_min), 0, num=int(pl.N/10))
-    _y = y(_Lx)
-    return scipy.interpolate.interp1d(np.log(_Lx), _y, kind='cubic', bounds_error=True)
+    _x = np.logspace(np.log10(pl.x_min), 0, num=int(pl.N/10))
+    _y = y(_x)
+    return scipy.interpolate.interp1d(np.log(_x), _y, kind='cubic', bounds_error=True)
 
 
 class TestPartonLumi(unittest.TestCase):

--- a/parton/test_plumi.py
+++ b/parton/test_plumi.py
@@ -16,9 +16,9 @@ def interpolator_slow(pl, p1, p2):
         def _int(x):
             return f1(x) * f2(t / x) / x
         return scipy.integrate.quad(lambda x: _int(x), t, 1)[0]
-    _x = np.linspace(1e-8, 1, num=pl.N)
-    _y = y(_x)
-    return scipy.interpolate.interp1d(_x, _y, kind='cubic', bounds_error=True)
+    _Lx = np.logspace(np.log10(pl.x_min), 0, num=int(pl.N/10))
+    _y = y(_Lx)
+    return scipy.interpolate.interp1d(np.log(_Lx), _y, kind='cubic', bounds_error=True)
 
 
 class TestPartonLumi(unittest.TestCase):
@@ -30,9 +30,9 @@ class TestPartonLumi(unittest.TestCase):
 
         for f in (0, 1, 4):
             int_slow = interpolator_slow(pl, f, -f)
-            for t in (0.2, 0.5, 0.7):
+            for t in (0.01, 0.05, 0.25):
                 L = pl.L(f, -f, t)
-                L_slow = int_slow(t)
-                self.assertAlmostEqual(L / L_slow, 1, delta=0.1,
+                L_slow = int_slow(np.log(t))
+                self.assertAlmostEqual(L / L_slow, 1, delta=0.01,
                                        msg="Failed for {}".format((f, t)))
         shutil.rmtree(dir)


### PR DESCRIPTION
This PR extends the range of the parton luminosity interpolation function. Previously, the lower boundary was fixed to e<sup>-10</sup>. Now the lower boundary is taken from the pdf set.

The following changes are made:
- the lower boundary of the interpolation range is determined from the `pdfgrids` and saved in the attribute `x_min`
- the precision of the interpolator is increased by setting the attribute `N=1000`
- the `_interpolator` method is slightly simplified by removing some `np.flip` and `np.ravel` and by using `np.logspace`
- the test is adjusted accordingly