### PR TITLE
Implement normal broadcasting semantics with grid=False

### DIFF
--- a/parton/pdf.py
+++ b/parton/pdf.py
@@ -216,7 +216,8 @@ class PDF(object):
         if grid == True:
             res = np.full((np.size(x), np.size(Q2)), np.nan)
         else:
-            res = np.full(np.broadcast_shapes(flavor, x, Q2), np.nan)
+            flavor, x, Q2 = map(np.asarray, (flavor, x, Q2))
+            res = np.full(np.broadcast_shapes(flavor.shape, x.shape, Q2.shape), np.nan)
         for i, pdfgrid in enumerate(self.pdfgrids):
             _res = pdfgrid.xfxQ2(flavor, x, Q2, grid=grid)
             res[np.isnan(res)] = _res[np.isnan(res)]

--- a/parton/pdf.py
+++ b/parton/pdf.py
@@ -36,6 +36,8 @@ class MyRectBivariateSpline(scipy.interpolate.RectBivariateSpline):
         The shape of the inputs and outputs is the same as for
         `scipy.interpolate.RectBivariateSpline`."""
         # the following code is taken from scipy/interpolate/interpolate.py
+        if not kwargs.get("grid", True) and x.shape != y.shape:
+            x, y = np.broadcast_arrays(x, y)
         if self.bounds_error or self.fill_value is not None:
             out_of_bounds_x = (x < self.x_min) | (x > self.x_max)
             out_of_bounds_y = (y < self.y_min) | (y > self.y_max)
@@ -57,10 +59,8 @@ class MyRectBivariateSpline(scipy.interpolate.RectBivariateSpline):
                 if any_out_of_bounds_y:
                     z[:, out_of_bounds_y] = self.fill_value
             else:
-                if any_out_of_bounds_x:
-                    z[out_of_bounds_x] = self.fill_value
-                if any_out_of_bounds_y:
-                    z[out_of_bounds_y] = self.fill_value
+                if any_out_of_bounds_x or any_out_of_bounds_y:
+                    z[out_of_bounds_x | out_of_bounds_y] = self.fill_value
         return z
 
 
@@ -180,10 +180,14 @@ class PDFGrid(object):
         flavors = np.unique(flavor)
         if grid and len(flavors) > 1:
             raise RuntimeError("No logical way to make a grid for multiple flavors")
-        out = self.interpolator(flavors[0])(np.log(x), np.log(Q2), grid=grid)
+        elif grid:
+            return self.interpolator(flavors[0])(np.log(x), np.log(Q2), grid=grid)
+        # this could be further optimized to not evaluate every point for every flavor
+        flavor, x, Q2 = np.broadcast_arrays(flavor, x, Q2)
+        out = self.interpolator(flavors[0])(np.log(x), np.log(Q2), grid=False)
         for f in flavors[1:]:
             mask = flavor == f
-            out[mask] = self.interpolator(f)(np.log(x), np.log(Q2), grid=grid)[mask]
+            out[mask] = self.interpolator(f)(np.log(x), np.log(Q2), grid=False)[mask]
         return out
 
 
@@ -212,7 +216,7 @@ class PDF(object):
         if grid == True:
             res = np.full((np.size(x), np.size(Q2)), np.nan)
         else:
-            res = np.full(np.size(x), np.nan)
+            res = np.full(np.broadcast_shapes(flavor, x, Q2), np.nan)
         for i, pdfgrid in enumerate(self.pdfgrids):
             _res = pdfgrid.xfxQ2(flavor, x, Q2, grid=grid)
             res[np.isnan(res)] = _res[np.isnan(res)]

--- a/parton/pdf.py
+++ b/parton/pdf.py
@@ -51,10 +51,16 @@ class MyRectBivariateSpline(scipy.interpolate.RectBivariateSpline):
         z = super().__call__(x, y, *args, **kwargs)
 
         if self.fill_value is not None:
-            if any_out_of_bounds_x:
-                z[out_of_bounds_x, :] = self.fill_value
-            if any_out_of_bounds_y:
-                z[:, out_of_bounds_y] = self.fill_value
+            if kwargs.get("grid", True):
+                if any_out_of_bounds_x:
+                    z[out_of_bounds_x, :] = self.fill_value
+                if any_out_of_bounds_y:
+                    z[:, out_of_bounds_y] = self.fill_value
+            else:
+                if any_out_of_bounds_x:
+                    z[out_of_bounds_x] = self.fill_value
+                if any_out_of_bounds_y:
+                    z[out_of_bounds_y] = self.fill_value
         return z
 
 
@@ -168,10 +174,17 @@ class PDFGrid(object):
             self._interpolators[flavor] = MyRectBivariateSpline(self.logx, self.logQ2, self.xfgrid[:, i].reshape(m, n), bounds_error=False, fill_value=np.nan)
         return self._interpolators[flavor]
 
-    def xfxQ2(self, flavor, x, Q2):
+    def xfxQ2(self, flavor, x, Q2, grid=True):
         """Return x*f(x) for flavor `flavor`, momentum fraction `x` and
         squared factorization scale in units of GeV^2, `Q2`."""
-        return self.interpolator(flavor)(np.log(x), np.log(Q2))
+        flavors = np.unique(flavor)
+        if grid and len(flavors) > 1:
+            raise RuntimeError("No logical way to make a grid for multiple flavors")
+        out = self.interpolator(flavors[0])(np.log(x), np.log(Q2), grid=grid)
+        for f in flavors[1:]:
+            mask = flavor == f
+            out[mask] = self.interpolator(f)(np.log(x), np.log(Q2), grid=grid)[mask]
+        return out
 
 
 class PDF(object):
@@ -188,25 +201,23 @@ class PDF(object):
         meta, grids = self.pdfmember.load()
         self.pdfgrids = [PDFGrid.from_block(grid) for grid in grids]
 
-    def xfxQ(self, flavor, x, Q):
+    def xfxQ(self, flavor, x, Q, grid=True):
         """Return x*f(x) by specifying flavor, `x`, and factorization scale
         `Q` in GeV."""
-        return self.xfxQ2(flavor, x, Q**2)
+        return self.xfxQ2(flavor, x, Q**2, grid=grid)
 
-    def xfxQ2(self, flavor, x, Q2):
+    def xfxQ2(self, flavor, x, Q2, grid=True):
         """Return x*f(x) by specifying flavor, `x`, and factorization scale
         squared `Q2` in GeV^2."""
-        res = np.empty((np.size(x), np.size(Q2)))
-        res[:] = np.nan
+        if grid == True:
+            res = np.full((np.size(x), np.size(Q2)), np.nan)
+        else:
+            res = np.full(np.size(x), np.nan)
         for i, pdfgrid in enumerate(self.pdfgrids):
-            _res = np.atleast_2d(pdfgrid.xfxQ2(flavor, x, Q2))
+            _res = pdfgrid.xfxQ2(flavor, x, Q2, grid=grid)
             res[np.isnan(res)] = _res[np.isnan(res)]
-            if np.any(np.isnan(res)):
-                continue
-            else:
-                if np.size(res) == 1:
-                    res = float(res)
-                return res
+            if not np.any(np.isnan(res)):
+                break
         if np.size(res) == 1:
             res = float(res)
         return res

--- a/parton/test_pdf.py
+++ b/parton/test_pdf.py
@@ -2,28 +2,35 @@ import unittest
 import tempfile
 import os
 import shutil
+import numpy as np
 from . import pdf, io
 import numpy as np
 
 
 class TestPDF(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._dir = tempfile.mkdtemp()
+        for pdfset in ['CT10', 'NNPDF31_nnlo_as_0118', 'NNPDF30_nnlo_as_0118']:
+            io.download_pdfset(pdfset, cls._dir)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls._dir)
+
     def test_init(self):
-        dir = tempfile.mkdtemp()
-        io.download_pdfset('CT10', dir)
-        set = pdf.PDFSet('CT10', pdfdir=dir)
+        set = pdf.PDFSet('CT10', pdfdir=self._dir)
         self.assertIsInstance(set.info, dict)
         member = pdf.PDFMember(set, 1)
         self.assertEqual(member.filename(),
-                         os.path.join(dir, 'CT10', 'CT10_0001.dat'))
+                         os.path.join(self._dir, 'CT10', 'CT10_0001.dat'))
         meta, grids = member.load()
         pdf.PDFGrid.from_block(grids[0])
-        shutil.rmtree(dir)
 
     def test_interpolators(self):
         dir = tempfile.mkdtemp()
         for pdfset in ['CT10', 'NNPDF31_nnlo_as_0118', 'NNPDF30_nnlo_as_0118']:
-            io.download_pdfset(pdfset, dir)
-            pd = pdf.PDF(pdfset, member=0, pdfdir=dir)
+            pd = pdf.PDF(pdfset, member=0, pdfdir=self._dir)
 
             for grid in pd.pdfgrids:
                 logx = grid.logx
@@ -42,4 +49,19 @@ class TestPDF(unittest.TestCase):
                                 self.assertAlmostEqual(grid.xfxQ2(flavor, x, Q2)/grid_values[ix, iQ2],
                                         1, delta=0.01,
                                         msg=f"Failed for {pdfset} with flavor {flavor}, x={x}, Q2={Q2} (interpolated: {grid.xfxQ2(flavor, x, Q2)}, grid: {grid_values[ix, iQ2]})")
-        shutil.rmtree(dir)
+
+    def test_broadcast(self):
+        pd = pdf.PDF('CT10', member=0, pdfdir=self._dir)
+        x = np.geomspace(1e-5, 1e-1, 10)
+        Q2 = np.geomspace(1, 1e4, 10)
+        np.testing.assert_array_equal(
+            pd.xfxQ2(1, x, Q2),
+            pd.xfxQ2(1, *np.meshgrid(x, Q2, indexing="ij"), grid=False),
+        )
+        flavor = np.array([0, 3, 1])
+        x = np.array([0.1, 0.2, 0.01])
+        Q2 = np.array([10, 100, 50])
+        np.testing.assert_array_equal(
+            np.vectorize(pd.xfxQ2)(flavor, x, Q2),
+            pd.xfxQ2(flavor, x, Q2, grid=False),
+        )

--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,5 @@ setup(
     long_description_content_type="text/markdown",
     license="MIT",
     packages=find_packages(),
-    install_requires=["numpy", "scipy", "setuptools", "pyyaml", "appdirs"],
+    install_requires=["numpy>=1.20.0", "scipy", "setuptools", "pyyaml", "appdirs"],
 )


### PR DESCRIPTION
Although good for making 2D grids of the pdf value, if we want to evaluate `mypdf.xfxQ` on a per-sample basis, it is more convenient to have the function broadcast, e.g.
```python
nnpdf31 = parton.mkPDF("NNPDF31_lo_as_0118", 0)
nnpdf31.xfxQ(
    np.array([1, 21, 21]),
    np.array([0.211, 0.038, 0.0581]),
    np.array([877, 231, 1.6e+03]),
    grid=False,
)
```
returns `array([0.17802354, 2.65219091, 1.44782397])` with this patch, whereas previously it would error because the x and Q values are not monotone increasing (as they would be for e.g. calls to `np.meshgrid`). With `grid=True` (the default) it should behave as before.

I would argue one is better off treating this function like a [ufunc](https://numpy.org/doc/stable/reference/ufuncs.html) and require the user to construct the grid with `np.meshgrid` for cases as in the original usage. This would be an API change though.