### PR TITLE
Tests fail for some pdf sets

### DIFF
--- a/parton/pdf.py
+++ b/parton/pdf.py
@@ -24,6 +24,12 @@ class MyRectBivariateSpline(scipy.interpolate.RectBivariateSpline):
         self.x_min, self.x_max = np.amin(x), np.amax(x)
         self.y_min, self.y_max = np.amin(y), np.amax(y)
 
+        # a small margin is added to the min and max values to avoid numerical issues
+        self.x_min = self.x_min - abs(self.x_min)/1e10
+        self.x_max = self.x_max + abs(self.x_max)/1e10
+        self.y_min = self.y_min - abs(self.y_min)/1e10
+        self.y_max = self.y_max + abs(self.y_max)/1e10
+
     def __call__(self, x, y, *args, **kwargs):
         """Call the `MyRectBivariateSpline` instance.
 

--- a/parton/test_pdf.py
+++ b/parton/test_pdf.py
@@ -3,6 +3,7 @@ import tempfile
 import os
 import shutil
 from . import pdf, io
+import numpy as np
 
 
 class TestPDF(unittest.TestCase):
@@ -16,4 +17,29 @@ class TestPDF(unittest.TestCase):
                          os.path.join(dir, 'CT10', 'CT10_0001.dat'))
         meta, grids = member.load()
         pdf.PDFGrid.from_block(grids[0])
+        shutil.rmtree(dir)
+
+    def test_interpolators(self):
+        dir = tempfile.mkdtemp()
+        for pdfset in ['CT10', 'NNPDF31_nnlo_as_0118', 'NNPDF30_nnlo_as_0118']:
+            io.download_pdfset(pdfset, dir)
+            pd = pdf.PDF(pdfset, member=0, pdfdir=dir)
+
+            for grid in pd.pdfgrids:
+                logx = grid.logx
+                logQ2 = grid.logQ2
+                xfgrid = grid.xfgrid
+                m = len(logx)
+                n = len(logQ2)
+
+                for flavor in grid.flavors:
+                    grid_values = xfgrid[:, grid.flav_index(flavor)].reshape(m, n)
+                    for ix, x in enumerate(np.exp(logx)):
+                        for iQ2, Q2 in enumerate(np.exp(logQ2)):
+                            if grid_values[ix, iQ2] < 1e-10:
+                                continue
+                            else:
+                                self.assertAlmostEqual(grid.xfxQ2(flavor, x, Q2)/grid_values[ix, iQ2],
+                                        1, delta=0.01,
+                                        msg=f"Failed for {pdfset} with flavor {flavor}, x={x}, Q2={Q2} (interpolated: {grid.xfxQ2(flavor, x, Q2)}, grid: {grid_values[ix, iQ2]})")
         shutil.rmtree(dir)

--- a/parton/test_plumi.py
+++ b/parton/test_plumi.py
@@ -24,15 +24,16 @@ def interpolator_slow(pl, p1, p2):
 class TestPartonLumi(unittest.TestCase):
     def test_plumi(self):
         dir = tempfile.mkdtemp()
-        io.download_pdfset('CT10', dir)
-        pd = pdf.PDF('CT10', member=0, pdfdir=dir)
-        pl = pdf.PLumi(pd, Q2=1000**2)
+        for pdfset in ['CT10', 'NNPDF31_nnlo_as_0118', 'NNPDF30_nnlo_as_0118']:
+            io.download_pdfset(pdfset, dir)
+            pd = pdf.PDF(pdfset, member=0, pdfdir=dir)
+            pl = pdf.PLumi(pd, Q2=1000**2)
 
-        for f in (0, 1, 4):
-            int_slow = interpolator_slow(pl, f, -f)
-            for t in (0.01, 0.05, 0.25):
-                L = pl.L(f, -f, t)
-                L_slow = int_slow(np.log(t))
-                self.assertAlmostEqual(L / L_slow, 1, delta=0.01,
-                                       msg="Failed for {}".format((f, t)))
+            for f in (0, 1, 4):
+                int_slow = interpolator_slow(pl, f, -f)
+                for t in (0.01, 0.05, 0.25):
+                    L = pl.L(f, -f, t)
+                    L_slow = int_slow(np.log(t))
+                    self.assertAlmostEqual(L / L_slow, 1, delta=0.01,
+                                        msg="Failed for {}".format((pdfset, f, t)))
         shutil.rmtree(dir)


### PR DESCRIPTION
This PR is to demonstrate (and hopefully fix) some tests failing for certain pdf sets.

As an example we add NNPDF versions 3.1 and 3.0 to `test_plumi`. For pdf sets `CT10` (already previously present in the test) and `NNPDF31_nnlo_as_0118` the tests pass. For `NNPDF30_nnlo_as_0118` the test fails (with the interpolated parton luminosities evaluating as `nan`s).

However, this only seems to occur on the github workflow. Locally, the tests pass also for NNPDF 3.0. 