### PR TITLE
Fix PDF file parsing for Hessian replicas

### DIFF
--- a/parton/pdf.py
+++ b/parton/pdf.py
@@ -1,5 +1,6 @@
 from . import io
 import os
+import re
 import yaml
 from io import StringIO
 import numpy as np
@@ -117,9 +118,12 @@ class PDFMember(object):
             raise ValueError("Data file {} not found".format(filename))
         with open(filename, 'r') as f:
             contents = f.read()
-        blocks = contents.split('\n---\n')
+        blocks = re.split(r'\n\s*---\s*\n', contents)
         meta = yaml.safe_load(blocks[0])
-        grids = blocks[1:-1]  # omit 1st (YAML) and last (empty) block
+        if len(blocks) > 1 and not blocks[-1].strip():
+            grids = blocks[1:-1]  # omit first (YAML) and last (empty) block
+        else:
+            grids = blocks[1:]  # only omit first (YAML) block
         return meta, grids
 
 

--- a/parton/pdf.py
+++ b/parton/pdf.py
@@ -118,7 +118,7 @@ class PDFMember(object):
             raise ValueError("Data file {} not found".format(filename))
         with open(filename, 'r') as f:
             contents = f.read()
-        blocks = re.split(r'\n\s*---\s*\n', contents)
+        blocks = re.split(r'\n\s*---\s*\n?', contents)
         meta = yaml.safe_load(blocks[0])
         if len(blocks) > 1 and not blocks[-1].strip():
             grids = blocks[1:-1]  # omit first (YAML) and last (empty) block


### PR DESCRIPTION
Unfortunately, the NNPDF31 files are not fully consistent. Specifically, the files of the replicas for the Hessian sets have a slightly different delimiter: "\n ---\n" instead of "\n---\n". For example, see:
```bash
[chpapage - parton]$ grep -r "\-\-\-" NNPDF31_nnlo_as_0118_hessian/
NNPDF31_nnlo_as_0118_hessian/NNPDF31_nnlo_as_0118_hessian_0000.dat:---
NNPDF31_nnlo_as_0118_hessian/NNPDF31_nnlo_as_0118_hessian_0000.dat:---
NNPDF31_nnlo_as_0118_hessian/NNPDF31_nnlo_as_0118_hessian_0000.dat:---
NNPDF31_nnlo_as_0118_hessian/NNPDF31_nnlo_as_0118_hessian_0001.dat:---
NNPDF31_nnlo_as_0118_hessian/NNPDF31_nnlo_as_0118_hessian_0001.dat: ---
NNPDF31_nnlo_as_0118_hessian/NNPDF31_nnlo_as_0118_hessian_0001.dat: ---
NNPDF31_nnlo_as_0118_hessian/NNPDF31_nnlo_as_0118_hessian_0002.dat:---
NNPDF31_nnlo_as_0118_hessian/NNPDF31_nnlo_as_0118_hessian_0002.dat: ---
NNPDF31_nnlo_as_0118_hessian/NNPDF31_nnlo_as_0118_hessian_0002.dat: ---
NNPDF31_nnlo_as_0118_hessian/NNPDF31_nnlo_as_0118_hessian_0003.dat:---
NNPDF31_nnlo_as_0118_hessian/NNPDF31_nnlo_as_0118_hessian_0003.dat: ---
NNPDF31_nnlo_as_0118_hessian/NNPDF31_nnlo_as_0118_hessian_0003.dat: ---
NNPDF31_nnlo_as_0118_hessian/NNPDF31_nnlo_as_0118_hessian_0004.dat:---
NNPDF31_nnlo_as_0118_hessian/NNPDF31_nnlo_as_0118_hessian_0004.dat: ---
NNPDF31_nnlo_as_0118_hessian/NNPDF31_nnlo_as_0118_hessian_0004.dat: ---
NNPDF31_nnlo_as_0118_hessian/NNPDF31_nnlo_as_0118_hessian_0005.dat:---
NNPDF31_nnlo_as_0118_hessian/NNPDF31_nnlo_as_0118_hessian_0005.dat: ---
NNPDF31_nnlo_as_0118_hessian/NNPDF31_nnlo_as_0118_hessian_0005.dat: ---
... and so on ...
```

This causes the grid to not be initiated correctly and all calculations yield NaN.

I have altered slightly the way the files are parsed by using a more flexible pattern-matching string that 1) allows an arbitrary number of spaces before and after "---", and 2) makes the last "\n" optional.